### PR TITLE
Merge yadutaf/go-ovh and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 go:
-- 1.4
 - 1.5
+- 1.6
 before_install:
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
+- go get github.com/golang/lint/golint
 - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
+- go vet ./...
+- $HOME/gopath/bin/golint ./...
 - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to govh
+
+## Submitting Modifications:
+
+So you want to contribute you work? Awesome! We are eager to review it.
+To submit your contribution, you must use Github Pull Requests. Your work
+does not need to be fully polished before submiting it. Actully, we love
+helping people writing a great contribution. Hence, if you are wondering
+how to integrate a specific change, feel free to start a discussion in
+a Pull Request.
+
+Before we can actually accept and merge a Pull Request, it will need
+to follow the conding guidelines (see below), and each commit shall be
+signed to indicate your full agreement with these guidelines and the
+DCO (see below).
+
+To sign a commit, you may use a command like:
+
+```
+# New commit
+git commit -s
+
+# Previous commit
+git commit --amend -s
+```
+
+If a Pull Request can not be automatically merged, you will probably need
+to "rebase" your work on latest project update:
+
+```
+# Assuming, this project remote is registered as "upstream"
+git fetch upstream
+git rebase upstream/master
+```
+
+## Contribution guidelines
+
+1. your code must follow the coding style rules (see below)
+2. your code must be documented
+3. you code must be tested
+4. your work must be signed (see "Developer Certificate of Origin" below)
+5. you may contribute through GitHub Pull Requests
+
+## Coding and documentation Style:
+
+- Code must be formated with `gofmt -sw ./`
+- Code must pass `go vet ./...`
+- Code must pass `golint ./...`
+
+## Licensing for new files:
+
+govh is licensed under a (modified) BSD license. Anything contributed to
+govh must be released under this license.
+
+When introducing a new file into the project, please make sure it has a
+copyright header making clear under which license it''s being released.
+
+## Developer Certificate of Origin:
+
+```
+To improve tracking of contributions to this project we will use a
+process modeled on the modified DCO 1.1 and use a "sign-off" procedure
+on patches that are being contributed.
+
+The sign-off is a simple line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right
+to pass it on as an open-source patch.  The rules are pretty simple:
+if you can certify the below:
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the open source license indicated in
+    the file; or
+
+(b) The contribution is based upon previous work that, to the best of
+    my knowledge, is covered under an appropriate open source License
+    and I have the right under that license to submit that work with
+    modifications, whether created in whole or in part by me, under
+    the same open source license (unless I am permitted to submit
+    under a different license), as indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) The contribution is made free of any other party''s intellectual
+    property claims or rights.
+
+(e) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+
+then you just add a line saying
+
+    Signed-off-by: Random J Developer <random@developer.org>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+```
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2015-2016, OVH SAS.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of OVH SAS nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY OVH SAS AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OVH SAS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -1,16 +1,114 @@
 govh
 ======
 
-Simple Go wrapper for the OVH API.
+Lightweight Go wrapper around OVH's APIs. Handles all the hard work including credential creation and requests signing.
 
 [![GoDoc](https://godoc.org/github.com/gregdel/govh?status.svg)](http://godoc.org/github.com/gregdel/govh)
 [![Build Status](https://travis-ci.org/gregdel/govh.svg?branch=master)](https://travis-ci.org/gregdel/govh)
 [![Coverage Status](https://coveralls.io/repos/gregdel/govh/badge.svg?branch=master&service=github)](https://coveralls.io/github/gregdel/govh?branch=master)
 [![Go Report Card](http://goreportcard.com/badge/gregdel/govh)](http://goreportcard.com/report/gregdel/govh)
 
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/gregdel/govh"
+)
+
+// PartialMe holds the first name of the currently logged-in user.
+// Visit https://api.ovh.com/console/#/me#GET for the full definition
+type PartialMe struct {
+	Firstname string `json:"firstname"`
+}
+
+// Instantiate an OVH client and get the firstname of the currently logged-in user.
+// Visit https://api.ovh.com/createToken/index.cgi?GET=/me to get your credentials.
+func main() {
+	var me PartialMe
+
+	client, _ := govh.NewClient(
+		"ovh-eu",
+		YOUR_APPLICATION_KEY,
+		YOUR_APPLICATION_SECRET,
+		YOUR_CONSUMER_KEY,
+	)
+	client.Get("/me", &me)
+	fmt.Printf("Welcome %s!\n", me.Firstname)
+}
+```
+
+## Installation
+
+The Golang wrapper has been tested with Golang 1.5+. It may worker with older versions although it has not been tested.
+
+To use it, just include it to your ``import`` and run ``go get``:
+
+```go
+import (
+	...
+	"github.com/gregdel/govh"
+)
+```
+
+## Configuration
+
+The straightforward way to use OVH's API keys is to embed them directly in the
+application code. While this is very convenient, it lacks of elegance and
+flexibility.
+
+Alternatively it is suggested to use configuration files or environment
+variables so that the same code may run seamlessly in multiple environments.
+Production and development for instance.
+
+This wrapper will first look for direct instanciation parameters then
+``OVH_ENDPOINT``, ``OVH_APPLICATION_KEY``, ``OVH_APPLICATION_SECRET`` and
+``OVH_CONSUMER_KEY`` environment variables. If either of these parameter is not
+provided, it will look for a configuration file of the form:
+
+```ini
+[default]
+; general configuration: default endpoint
+endpoint=ovh-eu
+
+[ovh-eu]
+; configuration specific to 'ovh-eu' endpoint
+application_key=my_app_key
+application_secret=my_application_secret
+consumer_key=my_consumer_key
+```
+
+The client will successively attempt to locate this configuration file in
+
+1. Current working directory: ``./ovh.conf``
+2. Current user's home directory ``~/.ovh.conf``
+3. System wide configuration ``/etc/ovh.conf``
+
+This lookup mechanism makes it easy to overload credentials for a specific
+project or user.
+
 ## Register your app
 
-Visit [https://eu.api.ovh.com/createApp](https://eu.api.ovh.com/createApp) and create your app. You'll get an application key and an application secret. To use the API you'll need a consumer key.
+OVH's API, like most modern APIs is designed to authenticate both an application and
+a user, without requiring the user to provide a password. Your application will be
+identified by its "application secret" and "application key" tokens.
+
+Hence, to use the API, you must first register your application and then ask your
+user to authenticate on a specific URL. Once authenticated, you'll have a valid
+"consumer key" which will grant your application on specific APIs.
+
+The user may choose the validity period of its authorization. The default period is
+24h. He may also revoke an authorization at any time. Hence, your application should
+be prepared to receive 403 HTTP errors and prompt the user to re-authenticated.
+
+This process is detailed in the following section. Alternatively, you may only need
+to build an application for a single user. In this case you may generate all
+credentials at once. See below.
+
+### Use the API on behalf of a user
+
+Visit [https://eu.api.ovh.com/createApp](https://eu.api.ovh.com/createApp) and create your app
+ You'll get an application key and an application secret. To use the API you'll need a consumer key.
 
 The consumer key has two types of restriction:
 
@@ -18,40 +116,52 @@ The consumer key has two types of restriction:
 * time: eg. expire in 1 day
 
 
-## Get a consumer key
-
-Here's an example on how to get your consumer key.
+Then, get a consumer key. Here's an example on how to generate one:
 
 ```go
 package main
 
 import (
-    "fmt"
+	"fmt"
 
-    "github.com/gregdel/govh"
+	"github.com/gregdel/govh"
 )
 
 func main() {
-    appKey := "you_app_key"
-    ckReq := govh.NewCkRequest(govh.OvhEU, appKey)
+	// Create a client using credentials from config files or environment variables
+	client, err := govh.NewEndpointClient("ovh-eu")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+	ckReq := client.NewCkRequest()
 
-    // Allow GET method on /me
-    ckReq.AddRule("GET", "/me")
+	// Allow GET method on /me
+	ckReq.AddRule("GET", "/me")
 
-    // Allow GET method on /xdsl and all its sub routes
-    ckReq.AddRule("GET", "/xdsl/*")
+	// Allow GET method on /xdsl and all its sub routes
+	ckReq.AddRule("GET", "/xdsl/*")
 
-    // Run the request
-    response, err := ckReq.Do()
-    if err != nil {
-        fmt.Printf("Error: %q\n", err)
-        return
-    }
+	// Run the request
+	response, err := ckReq.Do()
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
 
-    // Print the validation URL
-    fmt.Printf("%s",response)
+	// Print the validation URL and the Consumer key
+	fmt.Printf("Generated consumer key: %s\n", response.ConsumerKey)
+	fmt.Printf("Please visit %s to validate it\n", response.ValidationURL)
 }
 ```
+
+### Use the API for a single user
+
+Alternatively, you may generate all creadentials at once, including the consumer key. You will
+typically want to do this when writing automation scripts for a single projects.
+
+If this case, you may want to directly go to https://eu.api.ovh.com/createToken/ to generate
+the 3 tokens at once. Make sure to save them in one of the 'ovh.conf' configuration file.
 
 ## Use the lib
 
@@ -71,7 +181,11 @@ func main() {
 	as := "your_app_secret"
 	ck := "your_consumer_key"
 
-	client := govh.NewClient(govh.OvhEU, ak, as, ck)
+	client, err := govh.NewClient("ovh-eu", ak, as, ck)
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
 
 	// Get all the xdsl services
 	xdslServices := []string{}
@@ -84,11 +198,11 @@ func main() {
 	type xdslAccess struct {
 		Name   string `json:"accessName"`
 		Status string `json:"status"`
-		Pairs  int    `json:"pairsNumber"`
+		Pairs  int	`json:"pairsNumber"`
 		// Insert the other properties here
 	}
 
-        // Get the details of each service
+	// Get the details of each service
 	for i, serviceName := range xdslServices {
 		access := xdslAccess{}
 		url := "/xdsl/" + serviceName
@@ -118,7 +232,11 @@ func main() {
 	as := "your_app_secret"
 	ck := "your_consumer_key"
 
-	client := govh.NewClient(govh.OvhEU, ak, as, ck)
+	client, err := govh.NewClient("ovh-eu", ak, as, ck)
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
 
 	// Params
 	type AccessPutParams struct {
@@ -135,3 +253,174 @@ func main() {
 	fmt.Println("Description updated")
 }
 ```
+
+## API Documentation
+
+### Create a client
+
+- Use ``govh.NewClient()`` to have full controll over ther authentication
+- Use ``govh.NewEndpointClient()`` to create a client for a specific API and use credentials from config files or environment
+- Use ``govh.NewDefaultClient()`` to create a client unsing endpoint and credentials from config files or environment
+
+### Query
+
+Each HTTP verb has its own Client method. Some API methods supports unauthenticated calls. For
+these methods, you may want to use the ``*UnAuth`` variant of the Client which will bypass
+request signature.
+
+Each helper accepts a ``method`` and ``resType`` argument. ``method`` is the full URI, including
+the query string, and ``resType`` is a reference to an object in which the json response will
+be unserialized.
+
+Additionally, ``Post``, ``Put`` and their ``UnAuth`` variant accept a reqBody which is a
+reference to a json serializable object or nil.
+
+Alternatively, you may directly use the low level ``CallAPI`` method.
+
+- Use ``client.Get()`` for GET requests
+- Use ``client.Post()`` for POST requests
+- Use ``client.Put()`` for PUT requests
+- Use ``client.Delete()`` for DELETE requests
+
+Or, for unautenticated requests:
+
+- Use ``client.GetUnAuth()`` for GET requests
+- Use ``client.PostUnAuth()`` for POST requests
+- Use ``client.PutUnAuth()`` for PUT requests
+- Use ``client.DeleteUnAuth()`` for DELETE requests
+
+### Request consumer keys
+
+Consumer keys may be restricted to a subset of the API. This allows to delegate the API to manage
+only a specific server or domain name for example. This is called "scoping" a consumer key.
+
+Rules are simple. They combine an HTTP verb (GET, POST, PUT or DELETE) with a pattern. A pattern
+is a plain API method and may contain the '*' wilcard to match "anything". Just like glob on a
+Unix machine.
+
+While this is simple and may be managed directly with the API as-is, this can be cumbersome to do
+and we recommend using the ``CkRequest`` helper. It basically manages the list of authorizations
+for you and the actual request.
+
+*Create a ``CkRequest``*:
+
+```go
+req := client.NewCkRequest()
+```
+
+*Add a rule*:
+
+```go
+req.AddRule("VERB", "PATTERN")
+```
+
+*Create key*:
+
+```go
+pendingCk, err := req.Do()
+```
+
+This will initiate the consumer key validation process and return both a consumer key and
+a validation URL. The consumer key is automatically added to the client which was used to
+create the request. It may be used as soon as the user has authenticated the request on the
+validation URL.
+
+
+``pendingCk`` contains 3 fields:
+- ``ValidationURL`` the URL the user needs to visit to activate the consumer key
+- ``ConsumerKey`` the new consumer key. It won't be active until validation
+- ``State`` the consumer key state. Always "pendingValidation" at this stage
+
+
+## Hacking
+
+This wrapper uses standard Go tools, so you should feel at home with it.
+Here is a quick outline of what it may look like.
+
+### Get the sources
+
+```
+go get github.com/gregdel/govh
+cd $GOPATH/src/github.com/gregdel/govh
+go get
+```
+
+You've developed a new cool feature ? Fixed an annoying bug ? We'd be happy
+to hear from you ! See [CONTRIBUTING.md](https://github.com/gregdel/govh/blob/master/CONTRIBUTING.md)
+for more informations
+
+### Run the tests
+
+Simply run ``go test``. Since we all love quality, please
+note that we do not accept contributions lowering coverage.
+
+```
+# Run all tests, with coverage
+go test -cover
+
+# Validate code quality
+golint ./...
+go vet ./...
+```
+
+## Supported APIs
+
+### OVH Europe
+
+- **Documentation**: https://eu.api.ovh.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://eu.api.ovh.com/console
+- **Create application credentials**: https://eu.api.ovh.com/createApp/
+- **Create script credentials** (all keys at once): https://eu.api.ovh.com/createToken/
+
+### OVH North America
+
+- **Documentation**: https://ca.api.ovh.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://ca.api.ovh.com/console
+- **Create application credentials**: https://ca.api.ovh.com/createApp/
+- **Create script credentials** (all keys at once): https://ca.api.ovh.com/createToken/
+
+### So you Start Europe
+
+- **Documentation**: https://eu.api.soyoustart.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://eu.api.soyoustart.com/console/
+- **Create application credentials**: https://eu.api.soyoustart.com/createApp/
+- **Create script credentials** (all keys at once): https://eu.api.soyoustart.com/createToken/
+
+### So you Start North America
+
+- **Documentation**: https://ca.api.soyoustart.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://ca.api.soyoustart.com/console/
+- **Create application credentials**: https://ca.api.soyoustart.com/createApp/
+- **Create script credentials** (all keys at once): https://ca.api.soyoustart.com/createToken/
+
+### Kimsufi Europe
+
+- **Documentation**: https://eu.api.kimsufi.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://eu.api.kimsufi.com/console/
+- **Create application credentials**: https://eu.api.kimsufi.com/createApp/
+- **Create script credentials** (all keys at once): https://eu.api.kimsufi.com/createToken/
+
+### Kimsufi North America
+
+- **Documentation**: https://ca.api.kimsufi.com/
+- **Community support**: api-subscribe@ml.ovh.net
+- **Console**: https://ca.api.kimsufi.com/console/
+- **Create application credentials**: https://ca.api.kimsufi.com/createApp/
+- **Create script credentials** (all keys at once): https://ca.api.kimsufi.com/createToken/
+
+### Runabove
+
+- **Community support**: https://community.runabove.com/
+- **Console**: https://api.runabove.com/console/
+- **Create application credentials**: https://api.runabove.com/createApp/
+- **High level SDK**: https://github.com/runabove/python-runabove
+
+## License
+
+3-Clause BSD
+

--- a/configuration.go
+++ b/configuration.go
@@ -1,0 +1,123 @@
+package govh
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"gopkg.in/ini.v1"
+)
+
+// Use variables for easier test overload
+var (
+	systemConfigPath = "/etc/ovh.conf"
+	userConfigPath   = "/.ovh.conf" // prefixed with homeDir
+	localConfigPath  = "./ovh.conf"
+)
+
+// currentUserHome attempts to get current user's home directory
+func currentUserHome() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return usr.HomeDir, nil
+}
+
+// appendConfigurationFile only if it exists. We need to do this because
+// ini package will fail to load configuration at all if a configuration
+// file is missing. This is racy, but better than always failing.
+func appendConfigurationFile(cfg *ini.File, path string) {
+	if unix.Access(path, unix.R_OK) == nil {
+		cfg.Append(path)
+	}
+}
+
+// loadConfig loads client configuration from params, environments or configuration
+// files (by order of decreasing precedence).
+//
+// loadConfig will check OVH_CONSUMER_KEY, OVH_APPLICATION_KEY, OVH_APPLICATION_SECRET
+// and OVH_ENDPOINT environment variables. If any is present, it will take precedence
+// over any configuration from file.
+//
+// Configuration files are ini files. They share the same format as python-ovh,
+// node-ovh, php-ovh and all other wrappers. If any wrapper is configured, all
+// can re-use the same configuration. loadConfig will check for configuration in:
+//
+// - ./ovh.conf
+// - $HOME/.ovh.conf
+// - /etc/ovh.conf
+//
+func (c *Client) loadConfig(endpointName string) error {
+	// Load configuration files by order of increasing priority. All configuration
+	// files are optional. Only load file from user home if home could be resolve
+	cfg := ini.Empty()
+	appendConfigurationFile(cfg, systemConfigPath)
+	if home, err := currentUserHome(); err == nil {
+		userConfigFullPath := filepath.Join(home, userConfigPath)
+		appendConfigurationFile(cfg, userConfigFullPath)
+	}
+	appendConfigurationFile(cfg, localConfigPath)
+
+	// Canonicalize configuration
+	if endpointName == "" {
+		endpointName = getConfigValue(cfg, "default", "endpoint", "ovh-eu")
+	}
+
+	if c.appKey == "" {
+		c.appKey = getConfigValue(cfg, endpointName, "application_key", "")
+	}
+
+	if c.appSecret == "" {
+		c.appSecret = getConfigValue(cfg, endpointName, "application_secret", "")
+	}
+
+	if c.consumerKey == "" {
+		c.consumerKey = getConfigValue(cfg, endpointName, "consumer_key", "")
+	}
+
+	// Load real endpoint URL by name. If endpoint contains a '/', consider it as a URL
+	if strings.Contains(endpointName, "/") {
+		c.endpoint = Endpoint(endpointName)
+	} else {
+		c.endpoint = Endpoints[endpointName]
+	}
+
+	// If we still have no valid endpoint, appKey or appSecret, return an error
+	if c.endpoint == Endpoint("") {
+		return fmt.Errorf("Unknown endpoint '%s'. Consider checking 'Endpoints' list of using an URL.", endpointName)
+	}
+	if c.appKey == "" {
+		return fmt.Errorf("Missing application key. Please check your configuration or consult the documentation to create one.")
+	}
+	if c.appSecret == "" {
+		return fmt.Errorf("Missing application secret. Please check your configuration or consult the documentation to create one.")
+	}
+
+	return nil
+}
+
+// getConfigValue returns the value of OVH_<NAME> or ``name`` value from ``section``. If
+// the value could not be read from either env or any configuration files, return 'def'
+func getConfigValue(cfg *ini.File, section, name, def string) string {
+	// Attempt to load from environment
+	fromEnv := os.Getenv("OVH_" + strings.ToUpper(name))
+	if len(fromEnv) > 0 {
+		return fromEnv
+	}
+
+	// Attempt to load from configuration
+	fromSection := cfg.Section(section)
+	if fromSection == nil {
+		return def
+	}
+
+	fromSectionKey := fromSection.Key(name)
+	if fromSectionKey == nil {
+		return def
+	}
+	return fromSectionKey.String()
+}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -1,0 +1,263 @@
+package govh
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+//
+// Utils
+//
+
+var home string
+
+func setup() {
+	systemConfigPath = "./ovh.unittest.global.conf"
+	userConfigPath = "/.ovh.unittest.user.conf"
+	localConfigPath = "./ovh.unittest.local.conf"
+	home, _ = currentUserHome()
+}
+
+func teardown() {
+	os.Remove(systemConfigPath)
+	os.Remove(home + userConfigPath)
+	os.Remove(localConfigPath)
+}
+
+//
+// Tests
+//
+
+func TestConfigFromFiles(t *testing.T) {
+	// Write each parameter to one different configuration file
+	// This is a simple way to test precedence
+
+	// Prepare
+	ioutil.WriteFile(systemConfigPath, []byte(`
+[ovh-eu]
+application_key=system
+application_secret=system
+consumer_key=system
+`), 0660)
+
+	ioutil.WriteFile(home+userConfigPath, []byte(`
+[ovh-eu]
+application_secret=user
+consumer_key=user
+`), 0660)
+
+	ioutil.WriteFile(localConfigPath, []byte(`
+[ovh-eu]
+consumer_key=local
+`), 0660)
+
+	// Clear
+	defer ioutil.WriteFile(systemConfigPath, []byte(``), 0660)
+	defer ioutil.WriteFile(home+userConfigPath, []byte(``), 0660)
+	defer ioutil.WriteFile(localConfigPath, []byte(``), 0660)
+
+	// Test
+	client := Client{}
+	err := client.loadConfig("ovh-eu")
+
+	// Validate
+	if err != nil {
+		t.Fatalf("loadConfig failed with: '%v'", err)
+	}
+	if client.appKey != "system" {
+		t.Fatalf("client.appKey should be 'system'. Got '%s'", client.appKey)
+	}
+	if client.appSecret != "user" {
+		t.Fatalf("client.appSecret should be 'user'. Got '%s'", client.appSecret)
+	}
+	if client.consumerKey != "local" {
+		t.Fatalf("client.consumerKey should be 'local'. Got '%s'", client.consumerKey)
+	}
+}
+
+func TestConfigFromOnlyOneFile(t *testing.T) {
+	// ini package has a bug causing it to ignore all subsequent configuration
+	// files if any could not be loaded. Make sure that workaround... works.
+
+	// Prepare
+	os.Remove(systemConfigPath)
+	ioutil.WriteFile(home+userConfigPath, []byte(`
+[ovh-eu]
+application_key=user
+application_secret=user
+consumer_key=user
+`), 0660)
+
+	// Clear
+	defer ioutil.WriteFile(home+userConfigPath, []byte(``), 0660)
+
+	// Test
+	client := Client{}
+	err := client.loadConfig("ovh-eu")
+
+	// Validate
+	if err != nil {
+		t.Fatalf("loadConfig failed with: '%v'", err)
+	}
+	if client.appKey != "user" {
+		t.Fatalf("client.appKey should be 'user'. Got '%s'", client.appKey)
+	}
+	if client.appSecret != "user" {
+		t.Fatalf("client.appSecret should be 'user'. Got '%s'", client.appSecret)
+	}
+	if client.consumerKey != "user" {
+		t.Fatalf("client.consumerKey should be 'user'. Got '%s'", client.consumerKey)
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	// Prepare
+	ioutil.WriteFile(systemConfigPath, []byte(`
+[ovh-eu]
+application_key=fail
+application_secret=fail
+consumer_key=fail
+`), 0660)
+
+	defer ioutil.WriteFile(systemConfigPath, []byte(``), 0660)
+	os.Setenv("OVH_ENDPOINT", "ovh-eu")
+	os.Setenv("OVH_APPLICATION_KEY", "env")
+	os.Setenv("OVH_APPLICATION_SECRET", "env")
+	os.Setenv("OVH_CONSUMER_KEY", "env")
+
+	// Clear
+	defer os.Unsetenv("OVH_ENDPOINT")
+	defer os.Unsetenv("OVH_APPLICATION_KEY")
+	defer os.Unsetenv("OVH_APPLICATION_SECRET")
+	defer os.Unsetenv("OVH_CONSUMER_KEY")
+
+	// Test
+	client := Client{}
+	err := client.loadConfig("")
+
+	// Validate
+	if err != nil {
+		t.Fatalf("loadConfig failed with: '%v'", err)
+	}
+	if client.endpoint != OvhEU {
+		t.Fatalf("client.appKey should be 'env'. Got '%s'", client.appKey)
+	}
+	if client.appKey != "env" {
+		t.Fatalf("client.appKey should be 'env'. Got '%s'", client.appKey)
+	}
+	if client.appSecret != "env" {
+		t.Fatalf("client.appSecret should be 'env'. Got '%s'", client.appSecret)
+	}
+	if client.consumerKey != "env" {
+		t.Fatalf("client.consumerKey should be 'env'. Got '%s'", client.consumerKey)
+	}
+}
+
+func TestConfigFromArgs(t *testing.T) {
+	// Test
+	client := Client{
+		appKey:      "param",
+		appSecret:   "param",
+		consumerKey: "param",
+	}
+	err := client.loadConfig("ovh-eu")
+
+	// Validate
+	if err != nil {
+		t.Fatalf("loadConfig failed with: '%v'", err)
+	}
+	if client.endpoint != OvhEU {
+		t.Fatalf("client.appKey should be 'param'. Got '%s'", client.appKey)
+	}
+	if client.appKey != "param" {
+		t.Fatalf("client.appKey should be 'param'. Got '%s'", client.appKey)
+	}
+	if client.appSecret != "param" {
+		t.Fatalf("client.appSecret should be 'param'. Got '%s'", client.appSecret)
+	}
+	if client.consumerKey != "param" {
+		t.Fatalf("client.consumerKey should be 'param'. Got '%s'", client.consumerKey)
+	}
+}
+
+func TestEndpoint(t *testing.T) {
+	// Prepare
+	ioutil.WriteFile(systemConfigPath, []byte(`
+[ovh-eu]
+application_key=ovh
+application_secret=ovh
+consumer_key=ovh
+
+[https://api.example.com:4242]
+application_key=example.com
+application_secret=example.com
+consumer_key=example.com
+`), 0660)
+
+	// Clear
+	defer ioutil.WriteFile(systemConfigPath, []byte(``), 0660)
+
+	// Test: by name
+	client := Client{}
+	err := client.loadConfig("ovh-eu")
+	if err != nil {
+		t.Fatalf("loadConfig should not fail for endpoint 'ovh-eu'. Got '%v'", err)
+	}
+	if client.appKey != "ovh" {
+		t.Fatalf("configured value should be 'ovh' for endpoint 'ovh-eu'. Got '%s'", client.appKey)
+	}
+
+	// Test: by URL
+	client = Client{}
+	err = client.loadConfig("https://api.example.com:4242")
+	if err != nil {
+		t.Fatalf("loadConfig should not fail for endpoint 'https://api.example.com:4242'. Got '%v'", err)
+	}
+	if client.appKey != "example.com" {
+		t.Fatalf("configured value should be 'example.com' for endpoint 'https://api.example.com:4242'. Got '%s'", client.appKey)
+	}
+
+}
+
+func TestMissingParam(t *testing.T) {
+	// Setup
+	var err error
+	client := Client{
+		appKey:      "param",
+		appSecret:   "param",
+		consumerKey: "param",
+	}
+
+	// Test
+	client.endpoint = Endpoint("")
+	if err = client.loadConfig(""); err == nil {
+		t.Fatalf("loadConfig should fail when client.endpoint is missing. Got '%s'", client.endpoint)
+	}
+
+	client.appKey = ""
+	if err = client.loadConfig("ovh-eu"); err == nil {
+		t.Fatalf("loadConfig should fail when client.appKey is missing. Got '%s'", client.appKey)
+	}
+	client.appKey = "param"
+
+	client.appSecret = ""
+	if err = client.loadConfig("ovh-eu"); err == nil {
+		t.Fatalf("loadConfig should fail when client.appSecret is missing. Got '%s'", client.appSecret)
+	}
+	client.appSecret = "param"
+}
+
+//
+// Main
+//
+
+// TestMain changes the location of configuration files. We need
+// this to avoid any interference with existing configuration
+// and non-root users
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}

--- a/consumer_key_test.go
+++ b/consumer_key_test.go
@@ -1,120 +1,82 @@
 package govh
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
-	"reflect"
 	"testing"
 )
 
-var fakeAppKey = "7kbG7Bk7S9Nt7ZSV"
+// Common helpers are in govh_test.go
 
 func TestNewCkReqest(t *testing.T) {
-	// Expected headers
-	expectedHeaders := map[string]string{
-		"Content-Type":      "application/json",
-		"X-Ovh-Application": fakeAppKey,
-	}
-	// Received headers
-	receivedHeaders := map[string]string{}
+	const expectedRequest = `{"accessRules":[{"method":"GET","path":"/me"},{"method":"GET","path":"/xdsl/*"}]}`
 
-	// Received request
-	var receivedBody []byte
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Get the headers of the request
-		for h := range expectedHeaders {
-			receivedHeaders[h] = r.Header.Get(h)
-		}
-
-		// Get the content of the request
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "failed to read body", http.StatusInternalServerError)
-		}
-		defer r.Body.Close()
-		receivedBody = body
-
-		// Return a valid JSON result
-		fmt.Fprintln(w, `{
-			"validationUrl":"https://validation.url",
-			"consumerKey":"MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1",
-			"state":"pendingValidation"
-		}`)
-	}))
+	// Init test
+	var InputRequest *http.Request
+	var InputRequestBody string
+	ts, client := initMockServer(&InputRequest, 200, `{
+		"validationUrl":"https://validation.url",
+		"consumerKey":"`+MockConsumerKey+`",
+		"state":"pendingValidation"
+	}`, &InputRequestBody)
+	client.consumerKey = ""
 	defer ts.Close()
 
-	// Create a new ck request
-	endpoint := Endpoint(ts.URL)
-	ckRequest := NewCkRequest(endpoint, fakeAppKey)
+	// Test
+	ckRequest := client.NewCkRequest()
 	ckRequest.AddRule("GET", "/me")
 	ckRequest.AddRule("GET", "/xdsl/*")
 
-	// Run the request
 	got, err := ckRequest.Do()
+
+	// Validate
 	if err != nil {
-		t.Fatalf("expected no error, got %q", err)
+		t.Fatalf("CkRequest.Do() should not return an error. Got: %q", err)
 	}
-
-	// Check the headers
-	if !reflect.DeepEqual(expectedHeaders, receivedHeaders) {
-		t.Fatalf("invalid headers\nwanted: %+v\ngot: %+v\n", expectedHeaders, receivedHeaders)
+	if client.consumerKey != MockConsumerKey {
+		t.Fatalf("CkRequest.Do() should set client.consumerKey to %s. Got %s", MockConsumerKey, client.consumerKey)
 	}
-
-	// Check the request
-	receivedRequest := &CkRequest{}
-	if err = json.Unmarshal(receivedBody, receivedRequest); err != nil {
-		t.Fatalf("error during request unmarshal: %q", err)
+	if got.ConsumerKey != MockConsumerKey {
+		t.Fatalf("CkRequest.Do() should set CkValidationState.ConsumerKey to %s. Got %s", MockConsumerKey, got.ConsumerKey)
 	}
-	expectedRequest := &CkRequest{
-		AccessRules: []*AccessRule{
-			{Method: "GET", Path: "/me"},
-			{Method: "GET", Path: "/xdsl/*"},
-		},
+	if got.ValidationURL == "" {
+		t.Fatalf("CkRequest.Do() should set CkValidationState.ValidationURL")
 	}
-	if !reflect.DeepEqual(receivedRequest, expectedRequest) {
-		t.Fatalf("invalid ck request")
+	if InputRequestBody != expectedRequest {
+		t.Fatalf("CkRequest.Do() should issue '%s' request. Got %s", expectedRequest, InputRequestBody)
 	}
-
-	// Check the response
-	expected := &CkValidationState{
-		ValidationURL: "https://validation.url",
-		State:         "pendingValidation",
-		ConsumerKey:   "MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1",
-	}
-
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("unexpected response from new consumerKey requet")
-	}
+	ensureHeaderPresent(t, InputRequest, "Accept", "application/json")
+	ensureHeaderPresent(t, InputRequest, "X-Ovh-Application", MockApplicationKey)
 }
 
 func TestInvalidCkReqest(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message":"Invalid application key"}`, http.StatusUnauthorized)
-	}))
+	// Init test
+	var InputRequest *http.Request
+	var InputRequestBody string
+	ts, client := initMockServer(&InputRequest, http.StatusForbidden, `{"message":"Invalid application key"}`, &InputRequestBody)
+	client.consumerKey = ""
 	defer ts.Close()
 
-	// Create a new ck request
-	endpoint := Endpoint(ts.URL)
-	ckRequest := NewCkRequest(endpoint, fakeAppKey)
+	// Test
+	ckRequest := client.NewCkRequest()
 	ckRequest.AddRule("GET", "/me")
+	ckRequest.AddRule("GET", "/xdsl/*")
 
-	// Run the request
 	_, err := ckRequest.Do()
+	apiError, ok := err.(*APIError)
+
+	// Validate
 	if err == nil {
-		t.Fatal("expected an error, got none")
+		t.Fatal("Expected an error, got none")
 	}
-
-	expected := &APIError{
-		Code:    http.StatusUnauthorized,
-		Message: "Invalid application key",
+	if !ok {
+		t.Fatal("Expected error of type APIError")
 	}
-
-	if !reflect.DeepEqual(err, expected) {
-		t.Fatalf("unexpected error from get ck request")
+	if apiError.Code != http.StatusForbidden {
+		t.Fatalf("Expected HTTP error 403. Got %d", apiError.Code)
+	}
+	if apiError.Message != "Invalid application key" {
+		t.Fatalf("Expected API error message 'Invalid application key'. Got '%s'", apiError.Message)
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -2,7 +2,7 @@ package govh
 
 import "fmt"
 
-// APIOvhError represents an error that can occured while calling the API.
+// APIError represents an error that can occured while calling the API.
 type APIError struct {
 	// Error message.
 	Message string

--- a/govh.go
+++ b/govh.go
@@ -22,10 +22,25 @@ type Endpoint string
 
 // Endpoints
 const (
-	OvhEU    Endpoint = "https://api.ovh.com/1.0"
-	OvhCA             = "https://ca.api.ovh.com/1.0"
-	Runabove          = "https://api.runabove.com/1.0"
+	OvhEU        Endpoint = "https://eu.api.ovh.com/1.0"
+	OvhCA                 = "https://ca.api.ovh.com/1.0"
+	KimsufiEU             = "https://eu.api.kimsufi.com/1.0"
+	KimsufiCA             = "https://ca.api.kimsufi.com/1.0"
+	SoyoustartEU          = "https://eu.api.soyoustart.com/1.0"
+	SoyoustartCA          = "https://ca.api.soyoustart.com/1.0"
+	RunaboveCA            = "https://api.runabove.com/1.0"
 )
+
+// Endpoints conveniently maps endpoints names to their URI for external configuration
+var Endpoints = map[string]Endpoint{
+	"ovh-eu":        OvhEU,
+	"ovh-ca":        OvhCA,
+	"kimsufi-eu":    KimsufiEU,
+	"kimsufi-ca":    KimsufiCA,
+	"soyoustart-eu": SoyoustartEU,
+	"soyoustart-ca": SoyoustartCA,
+	"runabove-ca":   RunaboveCA,
+}
 
 // Errors
 var (

--- a/govh.go
+++ b/govh.go
@@ -73,29 +73,35 @@ type Client struct {
 }
 
 // NewClient represents a new client to call the API
-func NewClient(endpoint Endpoint, appKey, appSecret, consumerKey string) *Client {
-	return &Client{
+func NewClient(endpoint, appKey, appSecret, consumerKey string) (*Client, error) {
+	client := Client{
 		appKey:         appKey,
 		appSecret:      appSecret,
 		consumerKey:    consumerKey,
-		endpoint:       endpoint,
 		client:         &http.Client{},
 		timeDeltaMutex: &sync.Mutex{},
 		timeDeltaDone:  false,
 		Timeout:        time.Duration(DefaultTimeout * time.Second),
 	}
+
+	// Get and check the configuration
+	err := client.loadConfig(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &client, nil
 }
 
 // NewEndpointClient will create an API client for specified
 // endpoint and load all credentials from environment or
 // configuration files
-func NewEndpointClient(endpoint Endpoint) *Client {
+func NewEndpointClient(endpoint string) (*Client, error) {
 	return NewClient(endpoint, "", "", "")
 }
 
 // NewDefaultClient will load all it's parameter from environment
 // or configuration files
-func NewDefaultClient() *Client {
+func NewDefaultClient() (*Client, error) {
 	return NewClient("", "", "", "")
 }
 

--- a/govh_test.go
+++ b/govh_test.go
@@ -63,8 +63,7 @@ func initMockServer(InputRequest **http.Request, status int, responseBody string
 	}))
 
 	// Create client
-	endpoint := Endpoint(ts.URL)
-	client := NewClient(endpoint, MockApplicationKey, MockApplicationSecret, MockConsumerKey)
+	client, _ := NewClient(ts.URL, MockApplicationKey, MockApplicationSecret, MockConsumerKey)
 	client.timeDeltaDone = true
 
 	return ts, client

--- a/govh_test.go
+++ b/govh_test.go
@@ -32,7 +32,7 @@ type SomeData struct {
 // Utils
 //
 
-func initMockServer(InputRequest **http.Request, responseBody string, requestBody *string) (*httptest.Server, *Client) {
+func initMockServer(InputRequest **http.Request, status int, responseBody string, requestBody *string) (*httptest.Server, *Client) {
 	// Mock time
 	getLocalTime = func() time.Time {
 		return time.Unix(MockTime, 0)
@@ -58,6 +58,7 @@ func initMockServer(InputRequest **http.Request, responseBody string, requestBod
 
 		// Respond
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
 		fmt.Fprintln(w, responseBody)
 	}))
 
@@ -96,7 +97,7 @@ func Capitalize(s string) string {
 func TestTime(t *testing.T) {
 	// Init test
 	var InputRequest *http.Request
-	ts, client := initMockServer(&InputRequest, fmt.Sprintf("%d", MockTime), nil)
+	ts, client := initMockServer(&InputRequest, 200, fmt.Sprintf("%d", MockTime), nil)
 	defer ts.Close()
 
 	// Test
@@ -117,7 +118,7 @@ func TestTime(t *testing.T) {
 func TestPing(t *testing.T) {
 	// Init test
 	var InputRequest *http.Request
-	ts, client := initMockServer(&InputRequest, `0`, nil)
+	ts, client := initMockServer(&InputRequest, 200, `0`, nil)
 	defer ts.Close()
 
 	// Test
@@ -132,7 +133,7 @@ func TestPing(t *testing.T) {
 func TestPingUnreachable(t *testing.T) {
 	// Init test
 	var InputRequest *http.Request
-	ts, client := initMockServer(&InputRequest, `0`, nil)
+	ts, client := initMockServer(&InputRequest, 200, `0`, nil)
 	defer ts.Close()
 
 	// Test
@@ -151,7 +152,7 @@ func APIMethodTester(t *testing.T, HTTPmethod string, body interface{}, expected
 	// Init test
 	var InputRequest *http.Request
 	var InputRequestBody string
-	ts, client := initMockServer(&InputRequest, `"success"`, &InputRequestBody)
+	ts, client := initMockServer(&InputRequest, 200, `"success"`, &InputRequestBody)
 	defer ts.Close()
 
 	// Prepare method name

--- a/govh_test.go
+++ b/govh_test.go
@@ -1,254 +1,258 @@
 package govh
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strconv"
-	"sync"
+	"strings"
 	"testing"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
-func TestSig(t *testing.T) {
-	// Sig should be: "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
-	as := "EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF"
-	ck := "MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1"
-	method := "GET"
-	query := "https://eu.api.ovh.com/1.0/domains/"
-	var body string
-	ts := int64(1366560945)
+const (
+	// In case you wonder, these are real *revoked* credentials
+	MockApplicationKey    = "TDPKJdwZwAQPwKX2"
+	MockApplicationSecret = "9ufkBmLaTQ9nz5yMUlg79taH0GNnzDjk"
+	MockConsumerKey       = "5mBuy6SUQcRw2ZUxg0cG68BoDKpED4KY"
 
-	// Get sig
-	got := sig(as, ck, method, query, body, ts)
+	MockTime = 1457018875
+)
 
-	// Expected
-	expected := "$1$d3705e8afb27a0d2970a322b96550abfc67bb798"
+type SomeData struct {
+	IntValue    int    `json:"i_val,omitempty"`
+	StringValue string `json:"s_val,omitempty"`
+}
 
-	if got != expected {
-		t.Fatalf("invalid sig: got %q, expected %q", got, expected)
+//
+// Utils
+//
+
+func initMockServer(InputRequest **http.Request, responseBody string, requestBody *string) (*httptest.Server, *Client) {
+	// Mock time
+	getLocalTime = func() time.Time {
+		return time.Unix(MockTime, 0)
+	}
+
+	// Mock hostname, in signature only
+	getEndpointForSignature = func(c *Client) Endpoint {
+		return Endpoint("http://localhost")
+	}
+
+	// Create a fake API server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Save input parameters
+		*InputRequest = r
+		defer r.Body.Close()
+
+		if requestBody != nil {
+			reqBody, err := ioutil.ReadAll(r.Body)
+			if err == nil {
+				*requestBody = string(reqBody[:])
+			}
+		}
+
+		// Respond
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, responseBody)
+	}))
+
+	// Create client
+	endpoint := Endpoint(ts.URL)
+	client := NewClient(endpoint, MockApplicationKey, MockApplicationSecret, MockConsumerKey)
+	client.timeDeltaDone = true
+
+	return ts, client
+}
+
+func ensureHeaderPresent(t *testing.T, r *http.Request, name, value string) {
+	val, present := r.Header[name]
+
+	if !present {
+		t.Fatalf("%s requests should include a %s header with %s value.", r.Method, name, value)
+	}
+
+	if val[0] != value {
+		t.Fatalf("%s requests should include a %s header with %s value. Got %s", r.Method, name, value, val[0])
 	}
 }
+
+func Capitalize(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + strings.ToLower(s[n:])
+}
+
+//
+// Tests
+//
 
 func TestTime(t *testing.T) {
-	var apiCallCount int
-	expectedDelay := 10 * time.Second
-	expectedTime := time.Now().Add(expectedDelay)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiCallCount++
-		fmt.Fprintf(w, "%d", expectedTime.Unix())
-	}))
+	// Init test
+	var InputRequest *http.Request
+	ts, client := initMockServer(&InputRequest, fmt.Sprintf("%d", MockTime), nil)
 	defer ts.Close()
 
-	// Create a fake client
-	endpoint := Endpoint(ts.URL)
-	client := NewClient(endpoint, "ak", "as", "ck")
-
-	// Check that the time is correct
-	gotTime, err := client.Time()
+	// Test
+	serverTime, err := client.Time()
 	if err != nil {
-		t.Fatalf("expected not error, gotTime %q", err)
+		t.Fatalf("Unexpected error while retrieving server time: %v\n", err)
 	}
 
-	if expectedTime.Unix() != gotTime.Unix() {
-		t.Errorf("expeted %q, gotTime %q", expectedTime, gotTime)
+	// Validate
+	if InputRequest.Method != "GET" || InputRequest.URL.String() != "/auth/time" {
+		t.Fatalf("Time should be retrieved using GET /auth/time. Got %s %s", InputRequest.Method, InputRequest.URL.String())
 	}
-
-	// Get the delay between the current time and the API
-	gotDelay, err := delay(client.endpoint, &client.once)
-	if err != nil {
-		t.Fatalf("expected not error, got %q", err)
-	}
-
-	// The delay should be negative, we should use math.Floor to avoid dealing
-	// with nanoseconds
-	gotDelaySec := int(math.Floor(gotDelay.Seconds()))
-	expectedDelaySec := int(math.Floor(-1 * expectedDelay.Seconds()))
-	if gotDelaySec != expectedDelaySec {
-		t.Errorf("expeted %d, gotTime %d", expectedDelaySec, gotDelaySec)
-	}
-
-	// The delay functionn is used inside a once methhod, let's check if the
-	// call on the API to get the delay is really called once and only once.
-	// Let's call delay one more time and check that the time API as only been
-	// called twice (for the previous tests)
-	_, err = delay(client.endpoint, &client.once)
-	if err != nil {
-		t.Fatalf("expected not error, got %q", err)
-	}
-
-	if apiCallCount != 2 {
-		t.Errorf("expected 2 calls on time api, got %d", apiCallCount)
-	}
-}
-
-func TestAPIError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "", http.StatusInternalServerError)
-	}))
-	defer ts.Close()
-
-	// Check that the time is correct
-	_, err := getTime(Endpoint(ts.URL))
-	if err == nil {
-		t.Error("expected an error, got none")
-	}
-
-	if err != ErrAPIDown {
-		t.Errorf("expected %q, got %q", ErrAPIDown, err)
-	}
-}
-
-func TestGetResponse(t *testing.T) {
-	ak := "fakeKey"
-	as := "fakeAppSecret"
-	ck := "fakeCk"
-	now := time.Now()
-
-	// overwritte the time functions
-	delay = func(e Endpoint, o *sync.Once) (time.Duration, error) {
-		// No delay
-		return 0 * time.Second, nil
-	}
-	getTime = func(endpoint Endpoint) (*time.Time, error) {
-		return &now, nil
-	}
-
-	// Received headers
-	var receivedHeaders *http.Header
-	var receivedBody []byte
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedHeaders = &r.Header
-
-		// Get the content of the request
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "failed to read body", http.StatusInternalServerError)
-		}
-		defer r.Body.Close()
-		receivedBody = body
-
-		// Return a valid JSON result
-		fmt.Fprintln(w, `{"test_status":"passing"}`)
-	}))
-	defer ts.Close()
-
-	// Create a new client
-	endpoint := Endpoint(ts.URL)
-	client := NewClient(endpoint, ak, as, ck)
-
-	// Fake post params
-	type postParam struct {
-		What string `json:"what"`
-	}
-	postParams := &postParam{What: "Some data"}
-	expectedBody := []byte(`{"what":"Some data"}`)
-
-	// Expected response
-	type responseType struct {
-		TestStatus string `json:"test_status"`
-	}
-	resp := &responseType{}
-
-	// Make a post
-	if err := client.Post("/fakeURL", postParams, resp); err != nil {
-		t.Fatalf("expected no error, got %q", err)
-	}
-
-	// Check response body
-	if !bytes.Equal(expectedBody, receivedBody) {
-		t.Errorf("expected body %q, got %q", string(expectedBody), string(receivedBody))
-	}
-
-	// Check the response
-	expectedResponse := &responseType{
-		TestStatus: "passing",
-	}
-	if !reflect.DeepEqual(expectedResponse, resp) {
-		t.Fatalf("invalid response, got %+v, expected %+v", expectedResponse, resp)
-	}
-
-	// Check headers
-	for k, v := range map[string]string{
-		"Content-Type":      "application/json",
-		"X-Ovh-Timestamp":   strconv.FormatInt(time.Now().Unix(), 10),
-		"X-Ovh-Application": ak,
-		"X-Ovh-Consumer":    ck,
-	} {
-		h := receivedHeaders.Get(k)
-		if v != h {
-			t.Errorf("expected header %q received %q", v, h)
-		}
-	}
-
-	// The values of these headers is tested in other functions, we will only
-	// test their presence here
-	for _, k := range []string{"X-Ovh-Signature", "X-Ovh-Timestamp"} {
-		h := receivedHeaders.Get(k)
-		if h == "" {
-			t.Errorf("expected header %q received nothing", h)
-		}
-	}
-}
-
-func TestGetInvalidResponse(t *testing.T) {
-	code := http.StatusUnauthorized
-	msg := "what the fuck are you doing here"
-	expectedError := &APIError{Code: code, Message: msg}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ret := fmt.Sprintf("{%q:%q}", "message", msg)
-		http.Error(w, ret, code)
-	}))
-	defer ts.Close()
-
-	// Create a new client
-	endpoint := Endpoint(ts.URL)
-	client := NewClient(endpoint, "", "", "")
-
-	err := client.Get("/fakeURL", nil)
-	if err == nil {
-		t.Fatal("expected an error, got none")
-	}
-
-	if !reflect.DeepEqual(err, expectedError) {
-		t.Fatalf("invalid response, got %q, expected %q", err, expectedError)
+	if serverTime.Unix() != MockTime {
+		t.Fatalf("Server time should be %d. Got %d", MockTime, serverTime.Unix())
 	}
 }
 
 func TestPing(t *testing.T) {
-	getTime = func(endpoint Endpoint) (*time.Time, error) {
-		return nil, ErrAPIDown
-	}
+	// Init test
+	var InputRequest *http.Request
+	ts, client := initMockServer(&InputRequest, `0`, nil)
+	defer ts.Close()
 
-	client := NewClient(Endpoint("/fake"), "", "", "")
+	// Test
 	err := client.Ping()
-	if err == nil {
-		t.Fatal("expected an error, got none")
-	}
 
-	if err != ErrAPIDown {
-		t.Fatalf("expected %q, got %q", ErrAPIDown, err)
+	// Validate
+	if err != nil {
+		t.Fatalf("Unexpected error while pinging server: %v\n", err)
 	}
 }
 
-func TestDelay(t *testing.T) {
-	expectedDelay := 5 * time.Second
-	delay = func(e Endpoint, o *sync.Once) (time.Duration, error) {
-		return expectedDelay, nil
+func TestPingUnreachable(t *testing.T) {
+	// Init test
+	var InputRequest *http.Request
+	ts, client := initMockServer(&InputRequest, `0`, nil)
+	defer ts.Close()
+
+	// Test
+	client.endpoint = Endpoint("https://localhost:1/does not exist")
+	err := client.Ping()
+
+	// Validate
+	if err == nil {
+		t.Fatalf("Unexpected success while pinging server\n")
+	}
+}
+
+// APIMethodTester applies the same sanity checks to all main Client method. It checks the
+// request method, path, body and headers for both authenticated and unauthenticated variants
+func APIMethodTester(t *testing.T, HTTPmethod string, body interface{}, expectedBody string, expectedSignature string) {
+	// Init test
+	var InputRequest *http.Request
+	var InputRequestBody string
+	ts, client := initMockServer(&InputRequest, `"success"`, &InputRequestBody)
+	defer ts.Close()
+
+	// Prepare method name
+	needAuth := expectedSignature != ""
+	HTTPmethod = strings.ToUpper(HTTPmethod)
+	methodName := Capitalize(HTTPmethod)
+	if !needAuth {
+		methodName += "UnAuth"
 	}
 
-	client := NewClient(Endpoint("/fake"), "", "", "")
-	d, err := client.Delay()
+	// Prepare method arguments
+	var res interface{}
+	var arguments []reflect.Value
+	arguments = append(arguments, reflect.ValueOf("/some/resource"))
+	if body != nil {
+		arguments = append(arguments, reflect.ValueOf(body))
+	}
+	arguments = append(arguments, reflect.ValueOf(&res))
+
+	// Get method to test
+	method := reflect.ValueOf(client).MethodByName(methodName)
+	if !method.IsValid() {
+		t.Fatalf("Client should suport %s method\n", methodName)
+	}
+	ret := method.Call(arguments)
+	if !ret[0].IsNil() {
+		t.Fatalf("Unexpected error while retrieving server time: %v\n", ret[0])
+	}
+
+	// Log request details to help debugging
+	t.Logf("Request: %s %s. Authenticated=%v", InputRequest.Method, InputRequest.URL.String(), needAuth)
+	for key, value := range InputRequest.Header {
+		t.Logf("\tHEADER: key=%v, value=%v\n", key, value)
+	}
+
+	// Validate Method
+	if InputRequest.Method != HTTPmethod || InputRequest.URL.String() != "/some/resource" {
+		t.Fatalf("%s should trigger a %s /some/resource request. Got %s %s", methodName, HTTPmethod, InputRequest.Method, InputRequest.URL.String())
+	}
+
+	// Validate Body
+	if body != nil && expectedBody != InputRequestBody {
+		t.Fatalf("%s /some/resource should have '%s' body. Got '%s'", methodName, expectedBody, InputRequestBody)
+	}
+
+	// Validate Headers
+	ensureHeaderPresent(t, InputRequest, "Accept", "application/json")
+	ensureHeaderPresent(t, InputRequest, "X-Ovh-Application", MockApplicationKey)
+
+	if body != nil {
+		ensureHeaderPresent(t, InputRequest, "Content-Type", "application/json;charset=utf-8")
+	}
+
+	if needAuth {
+		ensureHeaderPresent(t, InputRequest, "X-Ovh-Timestamp", strconv.Itoa(MockTime))
+		ensureHeaderPresent(t, InputRequest, "X-Ovh-Consumer", MockConsumerKey)
+		ensureHeaderPresent(t, InputRequest, "X-Ovh-Signature", expectedSignature)
+	}
+
+}
+
+func TestAllAPIMethods(t *testing.T) {
+	body := SomeData{
+		IntValue:    42,
+		StringValue: "Hello World!",
+	}
+
+	APIMethodTester(t, "GET", nil, "", "$1$8a21169b341aa23e82192e07457ca978006b1ba9")
+	APIMethodTester(t, "GET", nil, "", "")
+	APIMethodTester(t, "DELETE", nil, "", "$1$f4571312a04a4c75188509e75c40581ca6bb6d7a")
+	APIMethodTester(t, "DELETE", nil, "", "")
+	APIMethodTester(t, "POST", body, `{"i_val":42,"s_val":"Hello World!"}`, "$1$6549d84e65be72f4ec0d7b6d7eaa19554a265990")
+	APIMethodTester(t, "POST", body, `{"i_val":42,"s_val":"Hello World!"}`, "")
+	APIMethodTester(t, "PUT", body, `{"i_val":42,"s_val":"Hello World!"}`, "$1$983e2a9a213c99211edd0b32715ac1ace1a6a0ea")
+	APIMethodTester(t, "PUT", body, `{"i_val":42,"s_val":"Hello World!"}`, "")
+}
+
+func TestGetResponse(t *testing.T) {
+	var err error
+	var apiInt int
+	mockClient := Client{}
+
+	// Nominal
+	err = mockClient.getResponse(&http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(strings.NewReader(`42`)),
+	}, &apiInt)
 	if err != nil {
-		t.Fatalf("expected no error, got %q", err)
+		t.Fatalf("Client.getResponse should be able to decode int when status is 200. Got %v", err)
 	}
 
-	if expectedDelay.Seconds() != d.Seconds() {
-		t.Fatalf("expected %s, got %s", expectedDelay, d)
+	// Error
+	err = mockClient.getResponse(&http.Response{
+		StatusCode: 400,
+		Body:       ioutil.NopCloser(strings.NewReader(`{"code": 400, "message": "Ooops..."}`)),
+	}, &apiInt)
+	if err == nil {
+		t.Fatalf("Client.getResponse should be able to decode an error when status is 400")
 	}
+	if _, ok := err.(*APIError); !ok {
+		t.Fatalf("Client.getResponse error should be an APIError when status is 400. Got '%s' of type %s", err, reflect.TypeOf(err))
+	}
+
 }


### PR DESCRIPTION
This is much more than a merge. I've taken the occasion to add some syntactic sugar, more tests, more documentation and all the Legal stuff to prepare the migration on github.com/ovh.

I've tried as much as possible to preserve the philosophy, if not the API of govh. But there are some breaking changes.

All commits should be fully functional. They all run cleanly through ``golint``, ``go vet`` and ``go test`` is happy with 85% coverage. Commits are logical units but I can easily squash them if you prefer.

Among the noteworthy evolutions, there are some more helpers in the Client and the consumer key helper has been made a first class citizen in the Client while keeping it cleanly isolated.

Let's review!